### PR TITLE
Update executor rbac, etc.

### DIFF
--- a/gitlab-runner/templates/configmap.yaml
+++ b/gitlab-runner/templates/configmap.yaml
@@ -34,6 +34,9 @@ data:
       --kubernetes-helper-memory-limit {{ default "" .Values.runners.helpers.memoryLimit | quote }} \
       --kubernetes-helper-cpu-request {{ default "" .Values.runners.helpers.cpuRequests | quote }} \
       --kubernetes-helper-memory-request {{ default "" .Values.runners.helpers.memoryRequests| quote }} \
+      {{- if .Values.runners.executorRbac.enabled }}
+      --kubernetes-service-account "{{ .Release.Name }}-gitlab-executor-serviceaccount" \
+      {{- end }}
       --kubernetes-poll-interval 3 \
       --kubernetes-poll-timeout 300
 

--- a/gitlab-runner/templates/deployment.yaml
+++ b/gitlab-runner/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               key: runner-registration-token
         livenessProbe:
           exec:
-            command: ["/usr/bin/pgrep","gitlab-ci-multi"]
+            command: ["/usr/bin/pgrep","gitlab.*runner"]
           initialDelaySeconds: 60
           timeoutSeconds: 1
           periodSeconds: 10
@@ -57,7 +57,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           exec:
-            command: ["/usr/bin/pgrep","gitlab-ci-multi"]
+            command: ["/usr/bin/pgrep","gitlab.*runner"]
           initialDelaySeconds: 10
           timeoutSeconds: 1
           periodSeconds: 10

--- a/gitlab-runner/templates/executor-rbac.yaml
+++ b/gitlab-runner/templates/executor-rbac.yaml
@@ -2,23 +2,34 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ .Values.runners.namespace | quote }}
   name: "{{ .Release.Name }}-gitlab-executor-serviceaccount"
 ---
-{{- $relname := .Release.Name -}}
-{{- $relnamespace := .Release.Namespace }}
-{{ range $i, $j := .Values.runners.executorRbac.rules }}
+{{- range $i, $j := .Values.runners.executorRbac.roles }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: "{{ $.Release.Name }}-executor-{{ $i }}-role"
+  namespace: {{ $j.namespace }}
+rules:
+{{- range $j.rules }}
+- apiGroups: {{ .apiGroups }}
+  resources: {{ .resources }}
+  verbs: {{ .verbs }}
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: "{{ $relname }}-executor-{{ $i }}-role-binding"
+  name: "{{ $.Release.Name }}-executor-{{ $i }}-role-binding"
   namespace: {{ $j.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ $j.role }}
+  name: "{{ $.Release.Name }}-executor-{{ $i }}-role"
 subjects:
   - kind: ServiceAccount
-    name: "{{ $relname }}-gitlab-executor-serviceaccount"
-    namespace: {{ $relnamespace }}
-{{ end }}
+    name: "{{ $.Release.Name }}-gitlab-executor-serviceaccount"
+    namespace: {{ $.Values.runners.namespace | quote }}
+{{- end }}
 {{- end }}

--- a/gitlab-runner/templates/rbac.yaml
+++ b/gitlab-runner/templates/rbac.yaml
@@ -5,25 +5,24 @@ metadata:
   name: "{{ .Release.Name }}-gitlab-runner-serviceaccount"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: "{{ $.Release.Name }}-gitlab-runner-role"
+  namespace: "{{ default .Release.Namespace .Values.runners.namespace }}"
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: "{{ .Release.Name }}-gitlab-role-binding"
+  namespace: "{{ default .Release.Namespace .Values.runners.namespace }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: admin
-subjects:
-  - kind: ServiceAccount
-    name: "{{ .Release.Name }}-gitlab-runner-serviceaccount"
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: "{{ .Release.Name }}-gitlab-clusterrole-binding"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
+  name: "{{ $.Release.Name }}-gitlab-runner-role"
 subjects:
   - kind: ServiceAccount
     name: "{{ .Release.Name }}-gitlab-runner-serviceaccount"

--- a/gitlab-runner/values.yaml
+++ b/gitlab-runner/values.yaml
@@ -1,7 +1,7 @@
 ## GitLab Runner Image
 ## ref: https://hub.docker.com/r/gitlab/gitlab-runner/tags/
 ##
-image: gitlab/gitlab-runner:v9.5.1
+image: gitlab/gitlab-runner:alpine-v10.1.0
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
@@ -86,9 +86,23 @@ runners:
 
   executorRbac:
     enabled: false
-    rules:
-    - role: edit
-      namespace: dummy
+    roles:
+    ## Give admin rights to namespace dummy
+    # - namespace: dummy
+    #   rules:
+    #   - apiGroups: '["*"]'
+    #     resources: '["*"]'
+    #     verbs: '["*"]'
+    ## Give connectability rights to default helm
+    # - namespace: kube-system
+    #   rules:
+    #   - apiGroups: '[""]'
+    #     resources: '["pods"]'
+    #     verbs: '["list"]'
+    #   - apiGroups: '[""]'
+    #     resources: '["pods/portforward]"]'
+    #     verbs: '["create", "delete"]'
+
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/gitlab-runner/values.yaml
+++ b/gitlab-runner/values.yaml
@@ -100,7 +100,7 @@ runners:
     #     resources: '["pods"]'
     #     verbs: '["list"]'
     #   - apiGroups: '[""]'
-    #     resources: '["pods/portforward]"]'
+    #     resources: '["pods/portforward"]'
     #     verbs: '["create", "delete"]'
 
 


### PR DESCRIPTION
This PR updates rbac to be a bit more sane for a more secure executor/runner.

Tested with

```yaml
rbac:
  enabled: true
resources:
  requests:
    cpu: 100m
    memory: 128Mi
  limits:
    cpu: 1000m
    memory: 128Mi    
runnerRegistrationToken: redacted
runners:
  builds:
    cpuRequests: 100m
    memoryRequests: 128Mi
    cpuLimit: 1000m
    memoryLimit: 128Mi    
  helpers:
    cpuRequests: 100m
    memoryRequests: 128Mi
    cpuLimit: 1000m
    memoryLimit: 128Mi    
  image: ubuntu:16.04
  namespace: ci-operations-gitlab
  privileged: true
  services:
    cpuRequests: 100m
    memoryRequests: 128Mi
    cpuLimit: 1000m
    memoryLimit: 128Mi    
  executorRbac:
    enabled: true
    roles:
    - namespace: ci-operations-tiller
      rules:
      - apiGroups: '[""]'
        resources: '["pods"]'
        verbs: '["list"]'
      - apiGroups: '[""]'
        resources: '["pods/portforward"]'
        verbs: '["create", "delete"]'
gitlabUrl: https://redacted.io/
```